### PR TITLE
Use deploy key with create-pull-request action

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/setup-python@v4
       - uses: browniebroke/pre-commit-autoupdate-action@main
       - uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ To use this repository as a template for your own application:
    ```bash
    pytest
    ```
+10. Follow the below steps on GitHub to create a Deploy Key needed for one of
+    the GitHub actions to work properly:
+    1. [Generate and save a deploy key], make sure to check "Allow write access"
+       when adding the key on GitHub.
+    1. [Add a secret] named SSH\_PRIVATE\_KEY by copy pasting the contents of
+       the private key file you generated in the previous step.
+
+[Generate and save a deploy key]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys
+[Add a secret]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+
 
 ### Updating Dependencies
 To add or remove dependencies:


### PR DESCRIPTION
It has been noted that PR's created by the `create-pull-request` action authenticating using `GITHUB_TOKEN` do not trigger further actions workflows. This is [documented](https://github.com/peter-evans/create-pull-request/issues/48) and a deliberate feature of PR's created by the `github-actions` bot. There are some [documented workarounds](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) for this. This PR implements the [deploy key](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-using-ssh-deploy-keys) workaround. The necessary deploy key and repository secret have already been added. I can't think of a way to test it in advance so if merged we should monitor the pre-commit auto-update workflow to see if it works.