### PR TITLE
Suppress ruff deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 addopts = "-v --mypy -p no:warnings --cov=myproject --cov-report=html --doctest-modules --ignore=myproject/__main__.py"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["D", "E", "F", "I"] # pydocstyle, pycodestyle, Pyflakes, isort
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D100", "D104"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
# Description

This suppresses a ruff deprecation warning. See https://github.com/ImperialCollegeLondon/MEDUSA/pull/49